### PR TITLE
Fix sdist and deprecate package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,3 +2,7 @@
 
 ## 1.0.1
 - `cymove` namespace is declared as safe to be called without holding GIL.
+
+## 1.0.2
+- Fixed missing pxd file and LICENSE in sdist (#1)
+- Added deprecation notice to README.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune .venv
+include LICENSE README.md cymove/__init__.pxd

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # cymove
 [![Build Status](https://travis-ci.org/ozars/cymove.svg?branch=master)](https://travis-ci.org/ozars/cymove) [![Build status](https://ci.appveyor.com/api/projects/status/j604r7xh12vp0hiu/branch/master?svg=true)](https://ci.appveyor.com/project/ozars/cymove/branch/master)
 
+***This package is DEPRECATED since `std::move` support is [merged][PR_URL] to Cython and available as of v0.29.17 (2020-04-26).***
+
+[PR_URL]: https://github.com/cython/cython/pull/3358
+
 cymove is a header (pxd) only wrapper around C++11 `std::move` function. It
 allows using move semantics from cython code.
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ opts = SetupOptions()
 
 opts.add(
     name='cymove',
-    version='1.0.1',
+    version='1.0.2',
     author='Omer Ozarslan',
     url='https://github.com/ozars/cymove',
     description='std::move wrapper for cython',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ opts.add(
     license='MIT',
     packages=['cymove'],
     include_package_data=True,
-    package_data={'': ['*.pxd']},
+    package_data={'': ['LICENSE', 'README.md', 'cymove/__init__.pxd']},
     zip_safe=False,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
- Fixed missing pxd file and LICENSE in sdist. Closes #1.
- Added deprecation notice to README. (cython/cython#3358)